### PR TITLE
Do not compare iconv_open result to zero

### DIFF
--- a/src/codegen/parsexml.xsl
+++ b/src/codegen/parsexml.xsl
@@ -29,7 +29,7 @@ char *fromXmlChar(const Context *ctx, const xmlChar *from_str) {
 	if (ctx-&gt;convertEncoding) {
 		size_t len = strlen((const char *)from_str);
 		iconv_t cd = iconv_open(ctx-&gt;swf_encoding, "UTF-8");
-		if (cd &lt; 0) {
+		if (cd == (iconv_t)-1) {
 			fprintf(stderr, "iconv_open failed.\n");
 			char *buf = new char[1];
 			buf[0] = '\0';

--- a/src/codegen/writexml.xsl
+++ b/src/codegen/writexml.xsl
@@ -25,7 +25,7 @@ xmlChar *toXmlChar(const Context *ctx, const char *from_str) {
 	if (ctx-&gt;convertEncoding) {
 		size_t len = strlen(from_str);
 		iconv_t cd = iconv_open("UTF-8", ctx-&gt;swf_encoding);
-		if (cd &lt; 0) {
+		if (cd == (iconv_t)-1) {
 			fprintf(stderr, "iconv_open failed.\n");
 			return xmlCharStrdup("");
 		}


### PR DESCRIPTION
Ordered comparison of `iconv_t` (which is, behind the scenes, a `void *`) with zero fails with recent clang, such as in Xcode 9 on macOS 10.13 (the system's default compiler). 

The standards clearly [state](http://pubs.opengroup.org/onlinepubs/7908799/xsh/iconv_open.html) that:

> Upon successful completion, iconv_open() returns a conversion descriptor for use on subsequent calls to iconv(). Otherwise iconv_open() returns (iconv_t)-1 and sets errno to indicate the error.

Thus the check for error is not `cd < 0` but `cd == (iconv_t)-1`.
