### PR TITLE
fix Freetype include

### DIFF
--- a/src/swft/swft_import_ttf.cpp
+++ b/src/swft/swft_import_ttf.cpp
@@ -14,7 +14,7 @@
 #include FT_OUTLINE_H
 #include "SWFShapeMaker.h"
 
-#include <freetype/tttables.h>
+#include FT_TRUETYPE_TABLES_H
 
 using namespace SWF;
 


### PR DESCRIPTION
Building with recent Freetype requires a change in the inclusion of tables. See analysis in http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=733356

Fixes #32 